### PR TITLE
change handler to only local logger

### DIFF
--- a/colourmap/colourmap.py
+++ b/colourmap/colourmap.py
@@ -13,13 +13,12 @@ import numpy as np
 import logging
 
 # Configure the logger
-logger = logging.getLogger('')
+logger = logging.getLogger(__name__)
 [logger.removeHandler(handler) for handler in logger.handlers[:]]
 console = logging.StreamHandler()
 formatter = logging.Formatter('[clustimage] >%(levelname)s> %(message)s')
 console.setFormatter(formatter)
 logger.addHandler(console)
-logger = logging.getLogger()
 
 
 # %% Main


### PR DESCRIPTION
All handlers are removed from the root logger and replace by a handler which logs with "[d3graph]" prefix. This causes that this prefix appears in logs from other modules. It also interferes with pytest log handles.
This PR performs the handler replacement only for the local logger.