### PR TITLE
Remove global logger configuration in colourmap module.

### DIFF
--- a/colourmap/colourmap.py
+++ b/colourmap/colourmap.py
@@ -13,8 +13,6 @@ import numpy as np
 import logging
 
 logger = logging.getLogger(__name__)
-if not logger.hasHandlers():
-    logging.basicConfig(level=logging.INFO, format='[{asctime}] [{name}] [{levelname}] {msg}', style='{', datefmt='%d-%m-%Y %H:%M:%S')
 
 
 # %% Main


### PR DESCRIPTION
This PR removes the global logger configuration in the colourmap module, such that it does not override the global logger configuration of the user.